### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Following is some example.
 
 ### `phpcs`
 
-> See https://github.com/squizlabs/PHP_CodeSniffer
+> See https://github.com/PHPCSStandards/PHP_CodeSniffer
 
 Run with default config.
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932